### PR TITLE
fix: replace unused 'cells' binding with '_' to resolve compiler warning

### DIFF
--- a/Projects/App/Sources/Excel/RNExcelController.swift
+++ b/Projects/App/Sources/Excel/RNExcelController.swift
@@ -85,7 +85,7 @@ class RNExcelController : NSObject{
         let headers = self.loadHeaders(from: sheet)
         
         let row = self.headerRow.advanced(by: 1)
-        let cells = self.loadCells(of: row, with: headers, in: sheet)
+        _ = self.loadCells(of: row, with: headers, in: sheet)
     }
     
     var subjects : [RNExcelSubject] = [];


### PR DESCRIPTION
Replaces the unused `cells` immutable binding with `_` on line 88 of RNExcelController.swift, resolving the compiler warning.

Fixes #27

Generated with [Claude Code](https://claude.ai/code)