### PR TITLE
fix: add AccentColor to main App asset catalog

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Resolves the Xcode warning "Accent color AccentColor is not present in any asset catalogs" by adding AccentColor.colorset to the main App's Assets.xcassets.

Fixes #28

Generated with [Claude Code](https://claude.ai/code)