### PR TITLE
ci: upgrade tuist to 4.140.2

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.131.1"
+tuist = "4.140.2"
 
 [env]
 TUIST_EXPERIMENTAL_MODULE_CACHE="1"


### PR DESCRIPTION
to fix Macro “TestingMacros” from package “swift-testing” must be enabled before it can be used 