### PR TITLE
fix: replace deprecated index(of:) with firstIndex(of:)

### DIFF
--- a/Projects/App/Sources/Excel/RNExcelController+RNExcelChapter.swift
+++ b/Projects/App/Sources/Excel/RNExcelController+RNExcelChapter.swift
@@ -71,7 +71,7 @@ extension RNExcelController{
                         return part.chapter == chapter.id;
                     }).forEach({ (part) in
                         chapter.parts.append(part);
-                        parts.remove(at: parts.index(of: part)!);
+                        parts.remove(at: parts.firstIndex(of: part)!);
                     })
                 }
             }

--- a/Projects/App/Sources/Excel/RNExcelController+RNExcelSubject.swift
+++ b/Projects/App/Sources/Excel/RNExcelController+RNExcelSubject.swift
@@ -57,7 +57,7 @@ extension RNExcelController{
                     return chapter.subject == subject.id;
                 }).forEach({ (chapter) in
                     subject.chapters.append(chapter);
-                    chapters.remove(at: chapters.index(of: chapter)!);
+                    chapters.remove(at: chapters.firstIndex(of: chapter)!);
                 })
             }
             


### PR DESCRIPTION
Replace deprecated Array.index(of:) method with firstIndex(of:) in:
- RNExcelController+RNExcelChapter.swift:74
- RNExcelController+RNExcelSubject.swift:60

Resolves #31

Generated with [Claude Code](https://claude.ai/code)