### PR TITLE
fix: replace deprecated .alert with .banner and .list for iOS 14.0+

### DIFF
--- a/Projects/App/Sources/Extensions/UserNotificationManager.swift
+++ b/Projects/App/Sources/Extensions/UserNotificationManager.swift
@@ -432,7 +432,7 @@ class UserNotificationManager : NSObject, UNUserNotificationCenterDelegate{
         print("receive push notification in foreground. identifier[\(id)] title[\(title)] body[\(body)] payload[\(payload)]");
         
         //UNNotificationPresentationOptions
-        completionHandler([.alert, .sound]);
+        completionHandler([.banner, .list, .sound]);
     }
 }
 


### PR DESCRIPTION
Fixes #34

Replace deprecated `UNNotificationPresentationOptions.alert` with `.banner` and `.list` to resolve the iOS 14.0 deprecation warning.

Generated with [Claude Code](https://claude.ai/code)