### PR TITLE
feat: add Renovate for automated dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,24 @@
+name: Renovate
+
+on:
+  # Disabled until tested — uncomment after confirming the workflow runs correctly
+  # schedule:
+  #   - cron: '0 0 * * 1'  # Every Monday at 9am KST (00:00 UTC)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: renovatebot/github-action@v46.1.4
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: 'debug'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.package\\(id:\\s*\"(?<depName>[\\w\\-.]+?)\"[\\s,]*from:\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "{{{replace '\\.' '/' depName}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.package\\(id:\\s*\"(?<depName>[\\w\\-.]+?)\"[\\s,]*from:\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "{{{replace '\\.' '/' depName}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s,]*requirement:\\s*\\.upToNextMajor\\(from:\\s*\"(?<currentValue>[^\"]+)\"\\)\\)"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s,]*requirement:\\s*\\.upToNextMajor\\(from:\\s*\"(?<currentValue>[^\"]+)\"\\)\\)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "groupName": "Swift dependencies",
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "matchDatasources": ["git-refs"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "matchUpdateTypes": ["minor", "major"],
+      "automerge": false
+    }
+  ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` with custom regex managers for Tuist Project.swift-based packages (both registry `id:` and URL `.remote()` formats)
- Adds `.github/workflows/renovate.yml` for self-hosted Renovate via GitHub Actions (schedule commented out — trigger manually first)
- Branch-pinned packages (DropDown) are excluded via `git-refs` datasource disable rule
- Patch updates auto-merge; minor/major require manual review

## Packages tracked
| Package | Format |
|---------|--------|
| firebase.firebase-ios-sdk | Registry |
| coreoffice.CoreXLSX | Registry |
| alamofire.Alamofire | Registry |
| scalessec.Toast-Swift | Registry |
| alexiscreuzot.SwiftyGif | Registry |
| reactivex.RxSwift | Registry |
| 2sem/GADManager | URL |
| 2sem/LProgressWebViewController | URL |
| 2sem/LSCountDownLabel | URL |
| 2sem/LSExtensions | URL |
| 2sem/StringLogger | URL |
| AssistoLab/DropDown | Excluded (branch pin) |

## Test plan
- [ ] Add `RENOVATE_TOKEN` secret to repo settings (Settings → Secrets → Actions)
- [ ] Merge this PR
- [ ] Trigger workflow manually from Actions tab → confirm it runs without errors
- [ ] Once confirmed, uncomment the `schedule` cron in `renovate.yml` and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)