### PR TITLE
fix: locate Crashlytics/run dynamically for Tuist registry

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -89,6 +89,21 @@ let project = Project(
                 .Projects.DynamicThirdParty,
                 .package(product: "GADManager", type: .runtime),
                 .target(name: "Widget")
+            ],
+            scripts: [
+                .post(
+                    script: """
+                    CRASHLYTICS_RUN=$(find "${BUILD_DIR%/Build/*}/SourcePackages" -name "run" -path "*/Crashlytics/*" | head -n 1)
+                    "$CRASHLYTICS_RUN"
+                    """,
+                    name: "Firebase Crashlytics",
+                    inputPaths: [
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+                        "${INFOPLIST_PATH}"
+                    ],
+                    basedOnDependencyAnalysis: false,
+                    runForInstallBuildsOnly: false
+                )
             ]
         ),
         .target(


### PR DESCRIPTION
## Summary

- Fixes archive failure after migration to Tuist registry (`firebase.firebase-ios-sdk`)
- Old hardcoded path `SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run` no longer exists — registry unpacks under `SourcePackages/registry/downloads/firebase/firebase-ios-sdk/{version}/`
- Replaces the hardcoded path with a `find` command that locates `Crashlytics/run` dynamically, regardless of where SPM stores the package

## Root Cause

```
SourcePackages/checkouts/firebase-ios-sdk/   ← old (pre-registry)
SourcePackages/registry/downloads/firebase/firebase-ios-sdk/{version}/  ← new (registry, version changes on every update)
```

The hardcoded path in the Crashlytics run script pointed to the old checkout location, causing the archive build phase to fail.

## Fix

```swift
.post(
    script: """
    CRASHLYTICS_RUN=$(find "${BUILD_DIR%/Build/*}/SourcePackages" -name "run" -path "*/Crashlytics/*" | head -n 1)
    "$CRASHLYTICS_RUN"
    """,
    name: "Firebase Crashlytics",
    inputPaths: [
        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
        "${INFOPLIST_PATH}"
    ],
    basedOnDependencyAnalysis: false,
    runForInstallBuildsOnly: false
)
```

## Test plan

- [ ] `mise x -- tuist generate --no-open` — project regenerates without errors
- [ ] Archive build succeeds (`xcodebuild archive`)
- [ ] Crashlytics build phase runs and locates `run` script in registry downloads path

🤖 Generated with [Claude Code](https://claude.com/claude-code)